### PR TITLE
Fix looping relationships

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# JSON API Link [![Build Status](https://travis-ci.com/Rsullivan00/apollo-link-json-api.svg?branch=master)](https://travis-ci.com/Rsullivan00/apollo-link-json-api)
+# JSON API Link [![Build Status](https://travis-ci.com/Rsullivan00/apollo-link-json-api.svg?branch=master)](https://travis-ci.com/Rsullivan00/apollo-link-json-api)  [![codecov](https://codecov.io/gh/Rsullivan00/apollo-link-json-api/branch/master/graph/badge.svg)](https://codecov.io/gh/Rsullivan00/apollo-link-json-api)
+
 
 ## Purpose
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JSON API Link
+# JSON API Link [![Build Status](https://travis-ci.com/Rsullivan00/apollo-link-json-api.svg?branch=master)](https://travis-ci.com/Rsullivan00/apollo-link-json-api)
 
 ## Purpose
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,3 +8,5 @@ coverage:
         target: "83%"
     patch:
       enabled: false
+
+comment: off

--- a/src/__tests__/jsonApiLink.ts
+++ b/src/__tests__/jsonApiLink.ts
@@ -1345,10 +1345,10 @@ describe('Query options', () => {
     it('sets the Accept: application/vnd.api+json header if not provided', async () => {
       expect.assertions(2);
 
-      fetchMock.get('/api/posts', []);
+      fetchMock.get('/api/posts', { data: [] });
       const postsQuery = gql`
         query posts {
-          posts @jsonapi(type: "Post", path: "/posts") {
+          posts @jsonapi(path: "/posts") {
             id
           }
         }
@@ -1397,13 +1397,15 @@ describe('Query options', () => {
       ]);
 
       const post = {
-        data: { type: 'posts', id: '1', attributes: { title: 'Love apollo' } },
+        type: 'posts',
+        id: '1',
+        attributes: { title: 'Love apollo' },
       };
-      fetchMock.get('/api/post/1', post);
+      fetchMock.get('/api/post/1', { data: post });
 
       const postTitleQuery = gql`
         query postTitle {
-          post(id: "1") @jsonapi(type: "Post", path: "/post/{args.id}") {
+          post(id: "1") @jsonapi(path: "/post/{args.id}") {
             id
             title
           }

--- a/src/__tests__/jsonApiLink.ts
+++ b/src/__tests__/jsonApiLink.ts
@@ -532,7 +532,7 @@ describe('Query single call', () => {
     });
   });
 
-  it('can query through nested and looping relationships', async () => {
+  it('can query through deeply nested and looping relationships', async () => {
     expect.assertions(1);
 
     const link = new JsonApiLink({ uri: '/api' });

--- a/src/jsonApiLink.ts
+++ b/src/jsonApiLink.ts
@@ -239,10 +239,6 @@ export namespace JsonApiLink {
      * @default Uses JsonApiLink.fieldNameDenormalizer
      */
     fieldNameDenormalizer?: JsonApiLink.FieldNameNormalizer;
-    /**
-     * A method to allow insertion of __typename deep in response objects
-     */
-    typePatcher?: JsonApiLink.FunctionalTypePatcher;
   }
 }
 

--- a/src/jsonApiLink.ts
+++ b/src/jsonApiLink.ts
@@ -264,8 +264,6 @@ const addTypeNameToResult = (
   __typename: string,
   typePatcher: JsonApiLink.FunctionalTypePatcher,
 ): any[] | object => {
-  console.log('In addTypeNameToResult');
-  console.log(result);
   if (Array.isArray(result)) {
     let fixedTypename;
     try {
@@ -277,8 +275,6 @@ const addTypeNameToResult = (
     const mappedResult = result.map(e =>
       addTypeNameToResult(e, fixedTypename, typePatcher),
     );
-    console.log('result', result);
-    console.log('mappedResult', mappedResult);
     return mappedResult;
   }
   if (
@@ -1089,7 +1085,6 @@ export class JsonApiLink extends ApolloLink {
 
     if (typePatcher == null) {
       this.typePatcher = (result, __typename, _2) => {
-        console.log(`Type patching ${__typename} into ${result.__typename}`);
         return { __typename, ...result };
       };
     } else if (

--- a/src/jsonApiTransformer.ts
+++ b/src/jsonApiTransformer.ts
@@ -91,9 +91,6 @@ const jsonapiResponseTransformer = async response =>
     .then(applyToData(typenameResource))
     .then(applyToData(denormalizeRelationships))
     .then(applyToData(flattenResource))
-    .then(({ data, included }) => data)
-    // TODO Remove this debugging code
-    // .then(r => console.log(r) || r)
-    .catch(e => console.error(e));
+    .then(({ data, included }) => data);
 
 export default jsonapiResponseTransformer;


### PR DESCRIPTION
This links looping relationship graphs and prevents infinite recursion.

It also fixes an issue where the top-level `data` resource could not be linked as a relationship in an `included` resource.