### PR TITLE
Fix case where `included` can be omitted if no included resources exist

### DIFF
--- a/src/__tests__/jsonApiLink.ts
+++ b/src/__tests__/jsonApiLink.ts
@@ -591,6 +591,49 @@ describe('Query single call', () => {
     });
   });
 
+  it('handles empty included relationships', async () => {
+    expect.assertions(1);
+
+    const link = new JsonApiLink({ uri: '/api' });
+    const author = {
+      id: '1',
+      type: 'authors',
+      attributes: { name: 'George R. R. Martin' },
+      relationships: { books: { data: [] } },
+    };
+
+    fetchMock.get('/api/authors/1?include=books', {
+      data: author,
+    });
+
+    const query = gql`
+      query authorQuery {
+        author @jsonapi(path: "/authors/1?include=books") {
+          id
+          books {
+            id
+            title
+          }
+        }
+      }
+    `;
+
+    const { data } = await makePromise<Result>(
+      execute(link, {
+        operationName: 'authorQuery',
+        query,
+      }),
+    );
+
+    expect(data).toMatchObject({
+      author: {
+        __typename: 'authors',
+        id: author.id,
+        books: [],
+      },
+    });
+  });
+
   it('ignores relationship and data links', async () => {
     expect.assertions(1);
 

--- a/src/jsonApiTransformer.ts
+++ b/src/jsonApiTransformer.ts
@@ -108,10 +108,7 @@ const _denormalizeRelationships = (
   return { ...data, relationships };
 };
 
-const denormalizeRelationships = (data: Resource, { included }) => {
-  if (!included) {
-    return data;
-  }
+const denormalizeRelationships = (data: Resource, { included = [] }) => {
   return _denormalizeRelationships(data, [data, ...included]);
 };
 


### PR DESCRIPTION
Closes https://github.com/Rsullivan00/apollo-link-json-api/issues/20