### PR TITLE
Expose full response with `includeJsonapi` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,59 @@ JSON API Link uses the `headers` field on the context to allow passing headers t
 - `headers`: an object representing values to be sent as headers on the request
 - `credentials`: a string representing the credentials policy you want for the fetch call
 
+## Accessing metadata and links
+
+By default, this library flattens your server response. If you need to access
+values that are unavailable by this simple querying method, you can add
+`includeJsonapi: true` to your `@jsonapi` directive, which will instead return
+the flattened "GraphQL-like" structure under a `graphql` key, and the original
+response structure under a `jsonapi` key. Resources are still nested in a tree
+structure under the `jsonapi` key, but `data`/`attribute`/`relatioship` keys are
+not flattened out.
+
+```gql
+query authorsWithMeta {
+  authors @jsonapi(path: "authors?include=series", includeJsonapi: true) {
+    graphql {
+      name
+      series {
+        title
+      }
+    }
+
+    jsonapi {
+      meta {
+        pageCount
+      }
+      links {
+        first
+        last
+        current
+      }
+      // The resource data is available here, though it's probably easier to
+      // grab from the `graphql` structure
+      data {
+        attributes {
+          name
+        }
+        relationships {
+          series {
+            data {
+              attributes {
+                title
+              }
+            }
+            links {
+              related
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 ## Contributing
 
 This project uses TypeScript to bring static types to JavaScript and uses Jest for testing. To get started, clone the repo and run the following commands:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-link-json-api",
-  "version": "0.0.8",
+  "version": "0.1.2",
   "description": "Query JSON API compliant services with GraphQL",
   "license": "MIT",
   "main": "./lib/bundle.umd.js",

--- a/src/__tests__/jsonApiLink.ts
+++ b/src/__tests__/jsonApiLink.ts
@@ -478,6 +478,7 @@ describe('Query single call', () => {
       type: 'comment',
       attributes: { text: 'hi' },
       links: { self: '/comments/3' },
+      relationships: { author: { links: { self: 'comments/3/author' } } },
     };
     const post = {
       data: {
@@ -548,6 +549,7 @@ describe('Query single call', () => {
 
     expect(data).toMatchObject({
       post: {
+        __typename: 'jsonapi_full_response_posts_body_wrapper',
         graphql: {
           title: post.data.attributes.title,
           author: {

--- a/src/__tests__/jsonApiLink.ts
+++ b/src/__tests__/jsonApiLink.ts
@@ -457,7 +457,7 @@ describe('Query single call', () => {
     });
   });
 
-  it('can access full response structure', async () => {
+  it('can access full response structure alongside flattened', async () => {
     expect.assertions(1);
     const link = new JsonApiLink({ uri: '/api' });
     const author = {
@@ -500,6 +500,15 @@ describe('Query single call', () => {
     const postTitleQuery = gql`
       query postTitle {
         post @jsonapi(path: "/post/1", includeJsonapi: true) {
+          graphql {
+            title
+            author {
+              name
+            }
+            comments {
+              text
+            }
+          }
           jsonapi {
             data {
               attributes {
@@ -539,6 +548,17 @@ describe('Query single call', () => {
 
     expect(data).toMatchObject({
       post: {
+        graphql: {
+          title: post.data.attributes.title,
+          author: {
+            name: author.attributes.name,
+          },
+          comments: [
+            {
+              text: comment.attributes.text,
+            },
+          ],
+        },
         jsonapi: {
           data: {
             attributes: {

--- a/src/__tests__/jsonApiLink.ts
+++ b/src/__tests__/jsonApiLink.ts
@@ -407,6 +407,56 @@ describe('Query single call', () => {
     });
   });
 
+  it('can access full response structure', async () => {
+    expect.assertions(1);
+    const link = new JsonApiLink({ uri: '/api' });
+    const post = {
+      data: {
+        id: '1',
+        type: 'posts',
+        attributes: { title: 'Love apollo' },
+      },
+      meta: {
+        my: 'stuff',
+      },
+      links: {
+        self: '/posts/1',
+      },
+    };
+    fetchMock.get('/api/post/1', post);
+
+    const postTitleQuery = gql`
+      query postTitle {
+        post @jsonapi(path: "/post/1", includeJsonapi: true) {
+          jsonapi {
+            meta {
+              my
+            }
+            links {
+              self
+            }
+          }
+        }
+      }
+    `;
+
+    const { data } = await makePromise<Result>(
+      execute(link, {
+        operationName: 'postTitle',
+        query: postTitleQuery,
+      }),
+    );
+
+    expect(data).toMatchObject({
+      post: {
+        jsonapi: {
+          meta: { my: 'stuff' },
+          links: { self: '/posts/1' },
+        },
+      },
+    });
+  });
+
   it('can handle array results', async () => {
     expect.assertions(1);
 

--- a/src/jsonApiLink.ts
+++ b/src/jsonApiLink.ts
@@ -217,6 +217,14 @@ export namespace JsonApiLink {
      * @default Uses JsonApiLink.fieldNameDenormalizer
      */
     fieldNameDenormalizer?: JsonApiLink.FieldNameNormalizer;
+
+    /**
+     * Restructures the query result to give access to the full response.
+     * Puts the flattened resource(s) under a `graphql` key, and returns the
+     * original response body structure under a `jsonapi` key.
+     * @default false
+     */
+    includeJsonapi?: boolean;
   }
 }
 
@@ -846,9 +854,13 @@ const resolver: Resolver = async (
   let {
     method,
     fieldNameDenormalizer: perRequestNameDenormalizer,
+    includeJsonapi,
   } = directives.jsonapi as JsonApiLink.DirectiveOptions;
   if (!method) {
     method = 'GET';
+  }
+  if (!includeJsonapi) {
+    includeJsonapi = false;
   }
 
   let body = undefined;
@@ -896,7 +908,11 @@ const resolver: Resolver = async (
       result = {};
     } else {
       try {
-        result = await jsonApiTransformer(response, typeNameNormalizer);
+        result = await jsonApiTransformer(
+          response,
+          typeNameNormalizer,
+          includeJsonapi,
+        );
       } catch (err) {
         console.warn('An error occurred in jsonApiTransformer:');
         throw err;

--- a/src/jsonApiTransformer.ts
+++ b/src/jsonApiTransformer.ts
@@ -47,7 +47,7 @@ interface JsonApiBody {
   links?: Links;
   jsonapi?: object;
 
-  jsonapiFullResponse?: JsonApiBody;
+  __jsonapi_full_response?: JsonApiBody;
 }
 
 const flattenResource = ({
@@ -124,11 +124,11 @@ const applyToIncluded = fn => ({ included, ...rest }: JsonApiBody) => {
 };
 
 const applyToJsonapiFullResponse = fn => ({
-  jsonapiFullResponse,
+  __jsonapi_full_response,
   ...rest
 }: JsonApiBody) =>
-  jsonapiFullResponse
-    ? { jsonapiFullResponse: fn(jsonapiFullResponse), ...rest }
+  __jsonapi_full_response
+    ? { __jsonapi_full_response: fn(__jsonapi_full_response), ...rest }
     : (rest as JsonApiBody);
 
 const applyNormalizer = (normalizer: JsonApiLink.TypeNameNormalizer) => (
@@ -207,9 +207,10 @@ const typenameNamespacer = (prefix, normalizer) => {
 const preserveBody = normalizer => async (body: JsonApiBody) => {
   return {
     ...body,
-    jsonapiFullResponse: typenameNamespacer('jsonapiFullResponse_', normalizer)(
-      body,
-    ),
+    __jsonapi_full_response: typenameNamespacer(
+      'jsonapi_full_response_',
+      normalizer,
+    )(body),
   } as JsonApiBody;
 };
 
@@ -227,8 +228,10 @@ const jsonapiResponseTransformer = async (
     .then(applyToData(flattenResource))
     .then(applyToJsonapiFullResponse(applyToIncluded(denormalizeRelationships)))
     .then(applyToJsonapiFullResponse(applyToData(denormalizeRelationships)))
-    .then(({ data, jsonapiFullResponse }) =>
-      includeJsonapi ? { graphql: data, jsonapi: jsonapiFullResponse } : data,
+    .then(({ data, __jsonapi_full_response }) =>
+      includeJsonapi
+        ? { graphql: data, jsonapi: __jsonapi_full_response }
+        : data,
     );
 
 export default jsonapiResponseTransformer;

--- a/src/jsonApiTransformer.ts
+++ b/src/jsonApiTransformer.ts
@@ -102,23 +102,14 @@ const _denormalizeRelationships = (
       if (!related.data) {
         return [relationshipName, null];
       }
-      if (Array.isArray(related.data)) {
-        return [
-          relationshipName,
-          related.data.map(item =>
-            _denormalizeRelationships(
-              findResource(item, allResources) || item,
-              allResources,
-            ),
-          ),
-        ];
-      }
       return [
         relationshipName,
-        _denormalizeRelationships(
-          findResource(related.data, allResources) || related.data,
-          allResources,
-        ),
+        applyToData(item =>
+          _denormalizeRelationships(
+            findResource(item, allResources) || item,
+            allResources,
+          ),
+        )(related).data,
       ];
     },
   );
@@ -144,29 +135,14 @@ const _denormalizeJsonapiRelationships = (
       if (!related.data) {
         return [relationshipName, related];
       }
-      if (Array.isArray(related.data)) {
-        return [
-          relationshipName,
-          {
-            ...related,
-            data: related.data.map(item =>
-              _denormalizeJsonapiRelationships(
-                findResource(item, allResources) || item,
-                allResources,
-              ),
-            ),
-          },
-        ];
-      }
       return [
         relationshipName,
-        {
-          ...related,
-          data: _denormalizeJsonapiRelationships(
-            findResource(related.data, allResources) || related.data,
+        applyToData(item =>
+          _denormalizeJsonapiRelationships(
+            findResource(item, allResources) || item,
             allResources,
           ),
-        },
+        )(related),
       ];
     },
   );

--- a/src/jsonApiTransformer.ts
+++ b/src/jsonApiTransformer.ts
@@ -191,10 +191,13 @@ const applyToIncluded = fn => ({ included, ...rest }: JsonApiBody) => {
   return { included: included.map(obj => fn(obj, rest)), ...rest };
 };
 
-const applyToJsonapiFullResponse = fn => ({ jsonapiFullResponse, ...rest }) =>
+const applyToJsonapiFullResponse = fn => ({
+  jsonapiFullResponse,
+  ...rest
+}: JsonApiBody) =>
   jsonapiFullResponse
     ? { jsonapiFullResponse: fn(jsonapiFullResponse), ...rest }
-    : rest;
+    : (rest as JsonApiBody);
 
 const applyNormalizer = (normalizer: JsonApiLink.TypeNameNormalizer) => (
   resource: Resource,
@@ -290,18 +293,12 @@ const jsonapiResponseTransformer = async (
     .then(applyToData(denormalizeRelationships))
     .then(applyToData(flattenResource))
     .then(
-      includeJsonapi
-        ? applyToJsonapiFullResponse(
-            applyToIncluded(denormalizeJsonapiRelationships),
-          )
-        : identity,
+      applyToJsonapiFullResponse(
+        applyToIncluded(denormalizeJsonapiRelationships),
+      ),
     )
     .then(
-      includeJsonapi
-        ? applyToJsonapiFullResponse(
-            applyToData(denormalizeJsonapiRelationships),
-          )
-        : identity,
+      applyToJsonapiFullResponse(applyToData(denormalizeJsonapiRelationships)),
     )
     .then(({ data, jsonapiFullResponse }) =>
       includeJsonapi ? { graphql: data, jsonapi: jsonapiFullResponse } : data,

--- a/src/jsonApiTransformer.ts
+++ b/src/jsonApiTransformer.ts
@@ -1,4 +1,4 @@
-import { mapObject } from './utils';
+import { mapObject, identity } from './utils';
 import { JsonApiLink } from './jsonApiLink';
 
 interface ResourceIdentifier {
@@ -8,9 +8,21 @@ interface ResourceIdentifier {
 
 type RelationshipData = ResourceIdentifier | Array<ResourceIdentifier>;
 
+interface LinkObject {
+  href?: string;
+  meta?: object;
+}
+
+type Link = string | LinkObject;
+
+interface Links {
+  [key: string]: Link;
+}
+
 interface RelationshipInfo {
-  links: object;
+  links?: Links;
   data?: RelationshipData;
+  meta?: object;
 }
 
 interface Relationships {
@@ -20,15 +32,22 @@ interface Relationships {
 interface Resource {
   id: string;
   type: string;
-  links: object;
-  attributes: object;
+  attributes?: object;
+  links?: Links;
+  meta?: object;
   relationships?: Relationships;
   __relationships_denormalizing?: boolean;
 }
 
 interface JsonApiBody {
-  data: Resource | Array<Resource>;
+  data?: Resource | Array<Resource>;
   included?: Array<Resource> | undefined;
+  meta?: object;
+  errors?: Array<Error>;
+  links?: Links;
+  jsonapi?: object;
+
+  jsonapi_full_response?: JsonApiBody;
 }
 
 const flattenResource = ({
@@ -131,16 +150,89 @@ const applyNormalizer = (normalizer: JsonApiLink.TypeNameNormalizer) => (
   ...resource,
 });
 
+const typeFor = (data: Resource | Array<Resource>) =>
+  Array.isArray(data) ? data[0] && data[0].type : data.type;
+
+const typenameNamespacer = (prefix, normalizer) => {
+  const resourceTypenameNamespacer = ({
+    attributes,
+    relationships,
+    meta,
+    links,
+    ...resource
+  }: Resource) => {
+    const __typename = normalizer(`${prefix}${resource.type}`);
+    return {
+      ...resource,
+      __typename,
+      attributes: attributes && {
+        ...attributes,
+        __typename: normalizer(`${__typename}_attributes`),
+      },
+      relationships: relationships && {
+        ...relationships,
+        __typename: normalizer(`${__typename}_relationships`),
+      },
+      meta: meta && {
+        ...meta,
+        __typename: normalizer(`${__typename}_meta`),
+      },
+      links: links && {
+        ...links,
+        __typename: normalizer(`${__typename}_links`),
+      },
+    };
+  };
+
+  const bodyTypenameNamespacer = body => {
+    const type = typeFor(body.data) || 'unknown';
+    return {
+      data:
+        body.data &&
+        (Array.isArray(body.data)
+          ? body.data.map(resourceTypenameNamespacer)
+          : resourceTypenameNamespacer(body.data)),
+      meta: body.meta && {
+        ...body.meta,
+        __typename: normalizer(`${prefix}${type}_body_meta`),
+      },
+      links: body.links && {
+        ...body.links,
+        __typename: normalizer(`${prefix}${type}_body_links`),
+      },
+      included: body.included
+        ? body.included.map(resourceTypenameNamespacer)
+        : body.included,
+      __typename: normalizer(`${prefix}${type}_body`),
+    };
+  };
+
+  return bodyTypenameNamespacer;
+};
+
+const preserveBody = normalizer => (body: JsonApiBody) =>
+  ({
+    ...body,
+    jsonapi_full_response: typenameNamespacer(
+      'jsonapi_full_response_',
+      normalizer,
+    )(body),
+  } as JsonApiBody);
+
 const jsonapiResponseTransformer = async (
   response: Response,
   typeNameNormalizer: JsonApiLink.TypeNameNormalizer,
+  includeJsonapi: boolean,
 ) =>
   response
     .json()
     .then(applyToIncluded(applyNormalizer(typeNameNormalizer)))
     .then(applyToData(applyNormalizer(typeNameNormalizer)))
     .then(applyToData(denormalizeRelationships))
+    .then(includeJsonapi ? preserveBody(typeNameNormalizer) : identity)
     .then(applyToData(flattenResource))
-    .then(({ data, included }) => data);
+    .then(({ data, jsonapi_full_response }) =>
+      includeJsonapi ? { graphql: data, jsonapi: jsonapi_full_response } : data,
+    );
 
 export default jsonapiResponseTransformer;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,7 +26,6 @@ export function removeRestSetsFromDocument(query: DocumentNode): DocumentNode {
   return docClone;
 }
 
-// TODO: Make a `mapObjectValues` instead
 export const mapObject = (obj, fn) =>
   Object.entries(obj)
     .map(fn)
@@ -34,5 +33,8 @@ export const mapObject = (obj, fn) =>
       acc[k] = v;
       return acc;
     }, {});
+
+export const mapObjectValues = (obj, fn) =>
+  mapObject(obj, ([k, v]) => [k, fn(v)]);
 
 export const identity = v => v;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,6 +26,7 @@ export function removeRestSetsFromDocument(query: DocumentNode): DocumentNode {
   return docClone;
 }
 
+// TODO: Make a `mapObjectValues` instead
 export const mapObject = (obj, fn) =>
   Object.entries(obj)
     .map(fn)


### PR DESCRIPTION
Closes #18 
Closes #12 

See the [readme changes](https://github.com/Rsullivan00/apollo-link-json-api/compare/rs/meta-nonbreaking?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8R185) for a summary.
